### PR TITLE
AWS apigateway enable-access-logging common metadata

### DIFF
--- a/aws/apigateway/enable-access-logging/metadata.rego
+++ b/aws/apigateway/enable-access-logging/metadata.rego
@@ -8,8 +8,8 @@ __rego_metadata__ := {
 	"description": "Ensures that Amazon API Gateway API stages have Amazon CloudWatch Logs enabled.",
 	"custom": {
 		"severity": "MEDIUM",
-		"possible_Impact": "Logging provides vital information about access and usage.",
-		"urls": ["https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html", "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage#access_log_settings"],
+		"possibleImpact": "Logging provides vital information about access and usage.",
+		"urls": ["https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html"],
 		"apis": ["APIGateway:getRestApis", "APIGateway:getStages"],
 		"iac": true,
 		"cspm": true

--- a/aws/apigateway/enable-access-logging/metadata.rego
+++ b/aws/apigateway/enable-access-logging/metadata.rego
@@ -1,0 +1,17 @@
+package cloud-metadata.aws.apigateway.enable-access-logging
+
+__rego_metadata__ := {
+	"id": "AWS061",
+	"apiVersion": 2,
+	"version": 1,
+	"title": "API Gateway stages for V1 and V2 should have access logging enabled",
+	"description": "Ensures that Amazon API Gateway API stages have Amazon CloudWatch Logs enabled.",
+	"custom": {
+		"severity": "MEDIUM",
+		"possible_Impact": "Logging provides vital information about access and usage.",
+		"urls": ["https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html", "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage#access_log_settings"],
+		"apis": ["APIGateway:getRestApis", "APIGateway:getStages"],
+		"iac": true,
+		"cspm": true
+	}
+}

--- a/aws/index.yaml
+++ b/aws/index.yaml
@@ -1,0 +1,2 @@
+- id: AWS061
+  file: aws/apigateway/enable-access-logging/metadata.rego


### PR DESCRIPTION
This commit include the first proposal for unify
Tfsec https://tfsec.dev/docs/aws/api-gateway/enable-access-logging/
And CSPM https://github.com/aquasecurity/cloudsploit/blob/master/plugins/aws/apigateway/apigatewayCloudwatchLogs.js