### PR TITLE
Add more CSPM cross referencing

### DIFF
--- a/aws/cloudwatch/log-group-customer-key/metadata.json
+++ b/aws/cloudwatch/log-group-customer-key/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-cloudwatch-log-group-customer-key"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-cloudwatch-log-group-customer-key"
       ]

--- a/aws/codebuild/enable-encryption/metadata.json
+++ b/aws/codebuild/enable-encryption/metadata.json
@@ -21,12 +21,7 @@
       "cfsec": [
         "aws-codebuild-enable-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-codebuild-enable-encryption"
       ]

--- a/aws/config/aggregate-all-regions/metadata.json
+++ b/aws/config/aggregate-all-regions/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-config-aggregate-all-regions"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-config-aggregate-all-regions"
       ]

--- a/aws/documentdb/enable-log-export/metadata.json
+++ b/aws/documentdb/enable-log-export/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-documentdb-enable-log-export"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-documentdb-enable-log-export"
       ]

--- a/aws/documentdb/enable-storage-encryption/metadata.json
+++ b/aws/documentdb/enable-storage-encryption/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-documentdb-enable-storage-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-documentdb-enable-storage-encryption"
       ]

--- a/aws/documentdb/encryption-customer-key/metadata.json
+++ b/aws/documentdb/encryption-customer-key/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-documentdb-encryption-customer-key"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-documentdb-encryption-customer-key"
       ]

--- a/aws/ec2/no-secrets-in-user-data/metadata.json
+++ b/aws/ec2/no-secrets-in-user-data/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-ec2-no-secrets-in-user-data"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ec2-no-secrets-in-user-data"
       ]

--- a/aws/ecr/enable-image-scans/metadata.json
+++ b/aws/ecr/enable-image-scans/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-ecr-enable-image-scans"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ecr-enable-image-scans"
       ]

--- a/aws/ecr/enforce-immutable-repository/metadata.json
+++ b/aws/ecr/enforce-immutable-repository/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 744,
+          "name": "ecr/ecrRepositoryTagImmutability"
         }
       ],
       "tfsec": [

--- a/aws/ecr/no-public-access/metadata.json
+++ b/aws/ecr/no-public-access/metadata.json
@@ -14,8 +14,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 523,
+          "name": "ecr/ecrRepositoryPolicy"
         }
       ],
       "tfsec": [

--- a/aws/ecr/repository-customer-key/metadata.json
+++ b/aws/ecr/repository-customer-key/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-ecr-repository-customer-key"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ecr-repository-customer-key"
       ]

--- a/aws/ecs/enable-container-insight/metadata.json
+++ b/aws/ecs/enable-container-insight/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-ecs-enable-container-insight"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ecs-enable-container-insight"
       ]

--- a/aws/ecs/enable-in-transit-encryption/metadata.json
+++ b/aws/ecs/enable-in-transit-encryption/metadata.json
@@ -21,12 +21,7 @@
       "cfsec": [
         "aws-ecs-enable-in-transit-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ecs-enable-in-transit-encryption"
       ]

--- a/aws/ecs/no-plaintext-secrets/metadata.json
+++ b/aws/ecs/no-plaintext-secrets/metadata.json
@@ -21,12 +21,7 @@
       "cfsec": [
         "aws-ecs-no-plaintext-secrets"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ecs-no-plaintext-secrets"
       ]

--- a/aws/efs/enable-at-rest-encryption/metadata.json
+++ b/aws/efs/enable-at-rest-encryption/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 375,
+          "name": "efs/efsEncryptionEnabled"
         }
       ],
       "tfsec": [

--- a/aws/eks/enable-control-plane-logging/metadata.json
+++ b/aws/eks/enable-control-plane-logging/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 513,
+          "name": "eks/eksLoggingEnabled"
         }
       ],
       "tfsec": [

--- a/aws/eks/encrypt-secrets/metadata.json
+++ b/aws/eks/encrypt-secrets/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-eks-encrypt-secrets"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-eks-encrypt-secrets"
       ]

--- a/aws/eks/no-public-cluster-access-to-cidr/metadata.json
+++ b/aws/eks/no-public-cluster-access-to-cidr/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 514,
+          "name": "eks/eksSecurityGroups"
         }
       ],
       "tfsec": [

--- a/aws/eks/no-public-cluster-access/metadata.json
+++ b/aws/eks/no-public-cluster-access/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 514,
+          "name": "eks/eksPrivateEndpoint"
         }
       ],
       "tfsec": [

--- a/aws/elastic-search/enable-domain-encryption/metadata.json
+++ b/aws/elastic-search/enable-domain-encryption/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 659,
+          "name": "es/esEncryptedDomain"
         }
       ],
       "tfsec": [

--- a/aws/elastic-search/enable-domain-logging/metadata.json
+++ b/aws/elastic-search/enable-domain-logging/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 661,
+          "name": "es/esLoggingEnabled"
         }
       ],
       "tfsec": [

--- a/aws/elastic-search/enable-in-transit-encryption/metadata.json
+++ b/aws/elastic-search/enable-in-transit-encryption/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 660,
+          "name": "es/esNodeToNodeEncryption"
         }
       ],
       "tfsec": [

--- a/aws/elastic-search/enable-logging/metadata.json
+++ b/aws/elastic-search/enable-logging/metadata.json
@@ -14,8 +14,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 661,
+          "name": "es/esLoggingEnabled"
         }
       ],
       "tfsec": [

--- a/aws/elastic-search/encrypt-replication-group/metadata.json
+++ b/aws/elastic-search/encrypt-replication-group/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-elastic-search-encrypt-replication-group"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elastic-search-encrypt-replication-group"
       ]

--- a/aws/elastic-search/enforce-https/metadata.json
+++ b/aws/elastic-search/enforce-https/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 663,
+          "name": "es/esHttpsOnly"
         }
       ],
       "tfsec": [

--- a/aws/elastic-search/use-secure-tls-policy/metadata.json
+++ b/aws/elastic-search/use-secure-tls-policy/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-elastic-search-use-secure-tls-policy"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elastic-search-use-secure-tls-policy"
       ]

--- a/aws/elasticache/add-description-for-security-group/metadata.json
+++ b/aws/elasticache/add-description-for-security-group/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-elasticache-add-description-for-security-group"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elasticache-add-description-for-security-group"
       ]

--- a/aws/elasticache/enable-backup-retention/metadata.json
+++ b/aws/elasticache/enable-backup-retention/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-elasticache-enable-backup-retention"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elasticache-enable-backup-retention"
       ]

--- a/aws/elasticache/enable-in-transit-encryption/metadata.json
+++ b/aws/elasticache/enable-in-transit-encryption/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-elasticache-enable-in-transit-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elasticache-enable-in-transit-encryption"
       ]

--- a/aws/elb/drop-invalid-headers/metadata.json
+++ b/aws/elb/drop-invalid-headers/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-elb-drop-invalid-headers"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elb-drop-invalid-headers"
       ]

--- a/aws/elbv2/alb-not-public/metadata.json
+++ b/aws/elbv2/alb-not-public/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-elbv2-alb-not-public"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-elbv2-alb-not-public"
       ]

--- a/aws/elbv2/http-not-used/metadata.json
+++ b/aws/elbv2/http-not-used/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 761,
+          "name": "elb/elbv2HttpsOnly"
         }
       ],
       "tfsec": [

--- a/aws/iam/block-kms-policy-wildcard/metadata.json
+++ b/aws/iam/block-kms-policy-wildcard/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-iam-block-kms-policy-wildcard"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-iam-block-kms-policy-wildcard"
       ]

--- a/aws/iam/no-password-reuse/metadata.json
+++ b/aws/iam/no-password-reuse/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 27,
+          "name": "passwordReusePrevention"
         }
       ],
       "tfsec": [

--- a/aws/iam/no-policy-wildcards/metadata.json
+++ b/aws/iam/no-policy-wildcards/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-iam-no-policy-wildcards"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-iam-no-policy-wildcards"
       ]

--- a/aws/iam/require-lowercase-in-passwords/metadata.json
+++ b/aws/iam/require-lowercase-in-passwords/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 244,
+          "name": "iam/passwordRequiresLowercase"
         }
       ],
       "tfsec": [

--- a/aws/iam/require-numbers-in-passwords/metadata.json
+++ b/aws/iam/require-numbers-in-passwords/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 245,
+          "name": "iam/passwordRequiresNumbers"
         }
       ],
       "tfsec": [

--- a/aws/iam/require-symbols-in-passwords/metadata.json
+++ b/aws/iam/require-symbols-in-passwords/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 25,
+          "name": "iam/passwordRequiresSymbols"
         }
       ],
       "tfsec": [

--- a/aws/iam/require-uppercase-in-passwords/metadata.json
+++ b/aws/iam/require-uppercase-in-passwords/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 246,
+          "name": "iam/passwordRequiresUppercase"
         }
       ],
       "tfsec": [

--- a/aws/iam/set-max-password-age/metadata.json
+++ b/aws/iam/set-max-password-age/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 26,
+          "name": "iam/maxPasswordAge"
         }
       ],
       "tfsec": [

--- a/aws/iam/set-minimum-password-length/metadata.json
+++ b/aws/iam/set-minimum-password-length/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 24,
+          "name": "iam/minPasswordLength"
         }
       ],
       "tfsec": [

--- a/aws/kinesis/enable-in-transit-encryption/metadata.json
+++ b/aws/kinesis/enable-in-transit-encryption/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-kinesis-enable-in-transit-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-kinesis-enable-in-transit-encryption"
       ]

--- a/aws/kms/auto-rotate-keys/metadata.json
+++ b/aws/kms/auto-rotate-keys/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 241,
+          "name": "kms/kmsKeyRotation"
         }
       ],
       "tfsec": [

--- a/aws/lambda/enable-tracing/metadata.json
+++ b/aws/lambda/enable-tracing/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-lambda-enable-tracing"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-lambda-enable-tracing"
       ]

--- a/aws/lambda/restrict-source-arn/metadata.json
+++ b/aws/lambda/restrict-source-arn/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-lambda-restrict-source-arn"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-lambda-restrict-source-arn"
       ]

--- a/aws/launch/no-sensitive-info/metadata.json
+++ b/aws/launch/no-sensitive-info/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-launch-no-sensitive-info"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-launch-no-sensitive-info"
       ]

--- a/aws/misc/no-exposing-plaintext-credentials/metadata.json
+++ b/aws/misc/no-exposing-plaintext-credentials/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-misc-no-exposing-plaintext-credentials"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-misc-no-exposing-plaintext-credentials"
       ]

--- a/aws/mq/enable-audit-logging/metadata.json
+++ b/aws/mq/enable-audit-logging/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-mq-enable-audit-logging"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-mq-enable-audit-logging"
       ]

--- a/aws/mq/enable-general-logging/metadata.json
+++ b/aws/mq/enable-general-logging/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-mq-enable-general-logging"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-mq-enable-general-logging"
       ]

--- a/aws/mq/no-public-access/metadata.json
+++ b/aws/mq/no-public-access/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-mq-no-public-access"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-mq-no-public-access"
       ]

--- a/aws/msk/enable-in-transit-encryption/metadata.json
+++ b/aws/msk/enable-in-transit-encryption/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-msk-enable-in-transit-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-msk-enable-in-transit-encryption"
       ]

--- a/aws/msk/enable-logging/metadata.json
+++ b/aws/msk/enable-logging/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-msk-enable-logging"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-msk-enable-logging"
       ]

--- a/aws/neptune/enable-log-export/metadata.json
+++ b/aws/neptune/enable-log-export/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-neptune-enable-log-export"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-neptune-enable-log-export"
       ]

--- a/aws/neptune/enable-storage-encryption/metadata.json
+++ b/aws/neptune/enable-storage-encryption/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-neptune-enable-storage-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-neptune-enable-storage-encryption"
       ]

--- a/aws/rds/backup-retention-specified/metadata.json
+++ b/aws/rds/backup-retention-specified/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-rds-backup-retention-specified"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-rds-backup-retention-specified"
       ]

--- a/aws/rds/enable-performance-insights/metadata.json
+++ b/aws/rds/enable-performance-insights/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-rds-enable-performance-insights"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-rds-enable-performance-insights"
       ]

--- a/aws/rds/encrypt-cluster-storage-data/metadata.json
+++ b/aws/rds/encrypt-cluster-storage-data/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 237,
+          "name": "rds/rdsEncryptionEnabled"
         }
       ],
       "tfsec": [

--- a/aws/rds/encrypt-instance-storage-data/metadata.json
+++ b/aws/rds/encrypt-instance-storage-data/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 237,
+          "name": "rds/rdsEncryptionEnabled"
         }
       ],
       "tfsec": [

--- a/aws/rds/no-classic-resources/metadata.json
+++ b/aws/rds/no-classic-resources/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-rds-no-classic-resources"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-rds-no-classic-resources"
       ]

--- a/aws/rds/no-public-db-access/metadata.json
+++ b/aws/rds/no-public-db-access/metadata.json
@@ -14,8 +14,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 239,
+          "name": "rds/rdsPubliclyAccessible"
         }
       ],
       "tfsec": [

--- a/aws/redshift/add-description-to-security-group/metadata.json
+++ b/aws/redshift/add-description-to-security-group/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-redshift-add-description-to-security-group"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-redshift-add-description-to-security-group"
       ]

--- a/aws/redshift/encryption-customer-key/metadata.json
+++ b/aws/redshift/encryption-customer-key/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-redshift-encryption-customer-key"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-redshift-encryption-customer-key"
       ]

--- a/aws/redshift/non-default-vpc-deployment/metadata.json
+++ b/aws/redshift/non-default-vpc-deployment/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-redshift-non-default-vpc-deployment"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-redshift-non-default-vpc-deployment"
       ]

--- a/aws/s3/block-public-acls/metadata.json
+++ b/aws/s3/block-public-acls/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-s3-block-public-acls"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-s3-block-public-acls"
       ]

--- a/aws/s3/block-public-policy/metadata.json
+++ b/aws/s3/block-public-policy/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-s3-block-public-policy"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-s3-block-public-policy"
       ]

--- a/aws/s3/enable-bucket-encryption/metadata.json
+++ b/aws/s3/enable-bucket-encryption/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 649,
+          "name": "s3/bucketEncryption"
         }
       ],
       "tfsec": [

--- a/aws/s3/enable-bucket-logging/metadata.json
+++ b/aws/s3/enable-bucket-logging/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 310,
+          "name": "s3/bucketLogging"
         }
       ],
       "tfsec": [

--- a/aws/s3/enable-versioning/metadata.json
+++ b/aws/s3/enable-versioning/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 300,
+          "name": "s3/bucketVersioning"
         }
       ],
       "tfsec": [

--- a/aws/s3/ignore-public-acls/metadata.json
+++ b/aws/s3/ignore-public-acls/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-s3-ignore-public-acls"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-s3-ignore-public-acls"
       ]

--- a/aws/s3/no-public-access-with-acl/metadata.json
+++ b/aws/s3/no-public-access-with-acl/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-s3-no-public-access-with-acl"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-s3-no-public-access-with-acl"
       ]

--- a/aws/s3/no-public-buckets/metadata.json
+++ b/aws/s3/no-public-buckets/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-s3-no-public-buckets"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-s3-no-public-buckets"
       ]

--- a/aws/s3/specify-public-access-block/metadata.json
+++ b/aws/s3/specify-public-access-block/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 741,
+          "name": "s3/bucketPublicAccessBlock"
         }
       ],
       "tfsec": [

--- a/aws/sns/enable-topic-encryption/metadata.json
+++ b/aws/sns/enable-topic-encryption/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 845,
+          "name": "sns/topicEncrypted"
         }
       ],
       "tfsec": [

--- a/aws/sqs/enable-queue-encryption/metadata.json
+++ b/aws/sqs/enable-queue-encryption/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 304,
+          "name": "sqs/sqsEncrypted"
         }
       ],
       "tfsec": [

--- a/aws/sqs/no-wildcards-in-policy-documents/metadata.json
+++ b/aws/sqs/no-wildcards-in-policy-documents/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-sqs-no-wildcards-in-policy-documents"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-sqs-no-wildcards-in-policy-documents"
       ]

--- a/aws/ssm/secret-use-customer-key/metadata.json
+++ b/aws/ssm/secret-use-customer-key/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-ssm-secret-use-customer-key"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-ssm-secret-use-customer-key"
       ]

--- a/aws/vpc/add-description-to-security-group/metadata.json
+++ b/aws/vpc/add-description-to-security-group/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-vpc-add-description-to-security-group"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-add-description-to-security-group"
       ]

--- a/aws/vpc/disallow-mixed-sgr/metadata.json
+++ b/aws/vpc/disallow-mixed-sgr/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-vpc-disallow-mixed-sgr"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-disallow-mixed-sgr"
       ]

--- a/aws/vpc/no-default-vpc/metadata.json
+++ b/aws/vpc/no-default-vpc/metadata.json
@@ -19,8 +19,8 @@
       ],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 311,
+          "name": "vpc/defaultVpcInUse"
         }
       ],
       "tfsec": [

--- a/aws/vpc/no-excessive-port-access/metadata.json
+++ b/aws/vpc/no-excessive-port-access/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-vpc-no-excessive-port-access"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-no-excessive-port-access"
       ]

--- a/aws/vpc/no-public-egress-sg/metadata.json
+++ b/aws/vpc/no-public-egress-sg/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-vpc-no-public-egress-sg"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-no-public-egress-sg"
       ]

--- a/aws/vpc/no-public-egress-sgr/metadata.json
+++ b/aws/vpc/no-public-egress-sgr/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-vpc-no-public-egress-sgr"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-no-public-egress-sgr"
       ]

--- a/aws/vpc/no-public-ingress-sg/metadata.json
+++ b/aws/vpc/no-public-ingress-sg/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-vpc-no-public-ingress-sg"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-no-public-ingress-sg"
       ]

--- a/aws/vpc/no-public-ingress-sgr/metadata.json
+++ b/aws/vpc/no-public-ingress-sgr/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-vpc-no-public-ingress-sgr"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-no-public-ingress-sgr"
       ]

--- a/aws/vpc/no-public-ingress/metadata.json
+++ b/aws/vpc/no-public-ingress/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-vpc-no-public-ingress"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-no-public-ingress"
       ]

--- a/aws/vpc/use-secure-tls-policy/metadata.json
+++ b/aws/vpc/use-secure-tls-policy/metadata.json
@@ -12,12 +12,7 @@
       "cfsec": [
         "aws-vpc-use-secure-tls-policy"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-vpc-use-secure-tls-policy"
       ]

--- a/aws/workspace/enable-disk-encryption/metadata.json
+++ b/aws/workspace/enable-disk-encryption/metadata.json
@@ -17,12 +17,7 @@
       "cfsec": [
         "aws-workspace-enable-disk-encryption"
       ],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "aws-workspace-enable-disk-encryption"
       ]

--- a/azure/appservice/account-identity-registered/metadata.json
+++ b/azure/appservice/account-identity-registered/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-appservice-account-identity-registered"
       ]

--- a/azure/appservice/authentication-enabled/metadata.json
+++ b/azure/appservice/authentication-enabled/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 420,
+          "name": "appservice/authEnabled"
         }
       ],
       "tfsec": [

--- a/azure/appservice/enable-http2/metadata.json
+++ b/azure/appservice/enable-http2/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 421,
+          "name": "appservice/http20Enabled"
         }
       ],
       "tfsec": [

--- a/azure/appservice/enforce-https/metadata.json
+++ b/azure/appservice/enforce-https/metadata.json
@@ -21,8 +21,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 383,
+          "name": "appservice/httpsOnlyEnabled"
         }
       ],
       "tfsec": [

--- a/azure/appservice/require-client-cert/metadata.json
+++ b/azure/appservice/require-client-cert/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 418,
+          "name": "appservice/clientCertEnabled"
         }
       ],
       "tfsec": [

--- a/azure/appservice/use-secure-tls-policy/metadata.json
+++ b/azure/appservice/use-secure-tls-policy/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 549,
+          "name": "appservice/tlsVersionCheck"
         }
       ],
       "tfsec": [

--- a/azure/authorization/limit-role-actions/metadata.json
+++ b/azure/authorization/limit-role-actions/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 672,
+          "name": "active-directory/noCustomOwnerRoles"
         }
       ],
       "tfsec": [

--- a/azure/compute/disable-password-authentication/metadata.json
+++ b/azure/compute/disable-password-authentication/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-compute-disable-password-authentication"
       ]

--- a/azure/compute/enable-disk-encryption/metadata.json
+++ b/azure/compute/enable-disk-encryption/metadata.json
@@ -17,8 +17,12 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 338,
+          "name": "virtualmachines/vmDiskOSEncryption"
+        },
+        {
+          "id": 339,
+          "name": "virtualmachines/vmDiskDataEncryption"
         }
       ],
       "tfsec": [

--- a/azure/compute/no-secrets-in-custom-data/metadata.json
+++ b/azure/compute/no-secrets-in-custom-data/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-compute-no-secrets-in-custom-data"
       ]

--- a/azure/compute/ssh-authentication/metadata.json
+++ b/azure/compute/ssh-authentication/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-compute-ssh-authentication"
       ]

--- a/azure/container/configured-network-policy/metadata.json
+++ b/azure/container/configured-network-policy/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-container-configured-network-policy"
       ]

--- a/azure/container/limit-authorized-ips/metadata.json
+++ b/azure/container/limit-authorized-ips/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-container-limit-authorized-ips"
       ]

--- a/azure/container/logging/metadata.json
+++ b/azure/container/logging/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-container-logging"
       ]

--- a/azure/container/use-rbac-permissions/metadata.json
+++ b/azure/container/use-rbac-permissions/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 511,
+          "name": "kubernetes-service/rbacEnabled"
         }
       ],
       "tfsec": [

--- a/azure/database/enable-audit/metadata.json
+++ b/azure/database/enable-audit/metadata.json
@@ -17,8 +17,16 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 596,
+          "name": "sqldatabases/dbAuditingEnabled"
+        },
+        {
+          "id": 625,
+          "name": "sqlserver/auditActionGroupsEnabled"
+        },
+        {
+          "id": 626,
+          "name": "sqlserver/serverAuditingEnabled"
         }
       ],
       "tfsec": [

--- a/azure/database/enable-ssl-enforcement/metadata.json
+++ b/azure/database/enable-ssl-enforcement/metadata.json
@@ -12,8 +12,12 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 651,
+          "name": "mysqlserver/enforceMySQLSSLConnection"
+        },
+        {
+          "id": 652,
+          "name": "postgresqlserver/enforcePostgresSSLConnection"
         }
       ],
       "tfsec": [

--- a/azure/database/no-public-access/metadata.json
+++ b/azure/database/no-public-access/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 591,
+          "name": "sqlserver/noPublicAccess"
         }
       ],
       "tfsec": [

--- a/azure/database/no-public-firewall-access/metadata.json
+++ b/azure/database/no-public-firewall-access/metadata.json
@@ -17,8 +17,20 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 414,
+          "name": "networksecuritygroups/openSQLServer"
+        },
+        {
+          "id": 411,
+          "name": "networksecuritygroups/openPostgreSQL"
+        },
+        {
+          "id": 623,
+          "name": "networksecuritygroups/openOracleAutoDataWarehouse"
+        },
+        {
+          "id": 409,
+          "name": "networksecuritygroups/openMySQL"
         }
       ],
       "tfsec": [

--- a/azure/database/postgres-configuration-log-checkpoints/metadata.json
+++ b/azure/database/postgres-configuration-log-checkpoints/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 622,
+          "name": "postgresqlserver/logCheckpointsEnabled"
         }
       ],
       "tfsec": [

--- a/azure/database/postgres-configuration-log-connection-throttling/metadata.json
+++ b/azure/database/postgres-configuration-log-connection-throttling/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 621,
+          "name": "postgresqlserver/logConnectionsEnabled"
         }
       ],
       "tfsec": [

--- a/azure/database/postgres-configuration-log-connections/metadata.json
+++ b/azure/database/postgres-configuration-log-connections/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-database-postgres-configuration-log-connections"
       ]

--- a/azure/database/retention-period-set/metadata.json
+++ b/azure/database/retention-period-set/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 624,
+          "name": "sqlserver/auditRetentionPolicy"
         }
       ],
       "tfsec": [

--- a/azure/database/secure-tls-policy/metadata.json
+++ b/azure/database/secure-tls-policy/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-database-secure-tls-policy"
       ]

--- a/azure/datafactory/no-public-access/metadata.json
+++ b/azure/datafactory/no-public-access/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-datafactory-no-public-access"
       ]

--- a/azure/datalake/enable-at-rest-encryption/metadata.json
+++ b/azure/datalake/enable-at-rest-encryption/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-datalake-enable-at-rest-encryption"
       ]

--- a/azure/functionapp/authentication-enabled/metadata.json
+++ b/azure/functionapp/authentication-enabled/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-functionapp-authentication-enabled"
       ]

--- a/azure/keyvault/content-type-for-secret/metadata.json
+++ b/azure/keyvault/content-type-for-secret/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-keyvault-content-type-for-secret"
       ]

--- a/azure/keyvault/ensure-key-expiry/metadata.json
+++ b/azure/keyvault/ensure-key-expiry/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 673,
+          "name": "keyvaults/secretExpirationEnabled"
         }
       ],
       "tfsec": [

--- a/azure/keyvault/ensure-secret-expiry/metadata.json
+++ b/azure/keyvault/ensure-secret-expiry/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 509,
+          "name": "keyvaults/keyExpirationEnabled"
         }
       ],
       "tfsec": [

--- a/azure/keyvault/no-purge/metadata.json
+++ b/azure/keyvault/no-purge/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 601,
+          "name": "keyvaults/kvRecoveryEnabled"
         }
       ],
       "tfsec": [

--- a/azure/keyvault/specify-network-acl/metadata.json
+++ b/azure/keyvault/specify-network-acl/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-keyvault-specify-network-acl"
       ]

--- a/azure/monitor/activity-log-retention-set/metadata.json
+++ b/azure/monitor/activity-log-retention-set/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 577,
+          "name": "monitor/logProfileRetentionPolicy"
         }
       ],
       "tfsec": [

--- a/azure/monitor/capture-all-activities/metadata.json
+++ b/azure/monitor/capture-all-activities/metadata.json
@@ -21,8 +21,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 502,
+          "name": "monitor/logProfileArchiveData"
         }
       ],
       "tfsec": [

--- a/azure/monitor/capture-all-regions/metadata.json
+++ b/azure/monitor/capture-all-regions/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 502,
+          "name": "monitor/logProfileArchiveData"
         }
       ],
       "tfsec": [

--- a/azure/mssql/all-threat-alerts-enabled/metadata.json
+++ b/azure/mssql/all-threat-alerts-enabled/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-mssql-all-threat-alerts-enabled"
       ]

--- a/azure/mssql/threat-alert-email-set/metadata.json
+++ b/azure/mssql/threat-alert-email-set/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-mssql-threat-alert-email-set"
       ]

--- a/azure/mssql/threat-alert-email-to-owner/metadata.json
+++ b/azure/mssql/threat-alert-email-to-owner/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-mssql-threat-alert-email-to-owner"
       ]

--- a/azure/network/disable-rdp-from-internet/metadata.json
+++ b/azure/network/disable-rdp-from-internet/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 405,
+          "name": "networksecuritygroups/openRDP"
         }
       ],
       "tfsec": [

--- a/azure/network/no-public-egress/metadata.json
+++ b/azure/network/no-public-egress/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-network-no-public-egress"
       ]

--- a/azure/network/no-public-ingress/metadata.json
+++ b/azure/network/no-public-ingress/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-network-no-public-ingress"
       ]

--- a/azure/network/retention-policy-set/metadata.json
+++ b/azure/network/retention-policy-set/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-network-retention-policy-set"
       ]

--- a/azure/network/ssh-blocked-from-internet/metadata.json
+++ b/azure/network/ssh-blocked-from-internet/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": -402,
+          "name": "networksecuritygroups/openSSH"
         }
       ],
       "tfsec": [

--- a/azure/security-center/alert-on-severe-notifications/metadata.json
+++ b/azure/security-center/alert-on-severe-notifications/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 669,
+          "name": "securitycenter/highSeverityAlertsEnabled"
         }
       ],
       "tfsec": [

--- a/azure/security-center/enable-standard-subscription/metadata.json
+++ b/azure/security-center/enable-standard-subscription/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 670,
+          "name": "securitycenter/standardPricingEnabled"
         }
       ],
       "tfsec": [

--- a/azure/security-center/set-required-contact-details/metadata.json
+++ b/azure/security-center/set-required-contact-details/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 584,
+          "name": "securitycenter/securityContactsEnabled"
         }
       ],
       "tfsec": [

--- a/azure/storage/allow-microsoft-service-bypass/metadata.json
+++ b/azure/storage/allow-microsoft-service-bypass/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 569,
+          "name": "storageaccounts/trustedMsAccessEnabled"
         }
       ],
       "tfsec": [

--- a/azure/storage/default-action-deny/metadata.json
+++ b/azure/storage/default-action-deny/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 415,
+          "name": "storageaccounts/networkAccessDefaultAction"
         }
       ],
       "tfsec": [

--- a/azure/storage/enforce-https/metadata.json
+++ b/azure/storage/enforce-https/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 334,
+          "name": "storageaccounts/storageAccountsHttps"
         }
       ],
       "tfsec": [

--- a/azure/storage/no-public-access/metadata.json
+++ b/azure/storage/no-public-access/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 499,
+          "name": "storageaccounts/logContainerPublicAccess"
         }
       ],
       "tfsec": [

--- a/azure/storage/queue-services-logging-enabled/metadata.json
+++ b/azure/storage/queue-services-logging-enabled/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-storage-queue-services-logging-enabled"
       ]

--- a/azure/storage/use-secure-tls-policy/metadata.json
+++ b/azure/storage/use-secure-tls-policy/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-storage-use-secure-tls-policy"
       ]

--- a/azure/synapse/virtual-network-enabled/metadata.json
+++ b/azure/synapse/virtual-network-enabled/metadata.json
@@ -19,12 +19,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "azure-synapse-virtual-network-enabled"
       ]

--- a/cloudstack/compute/no-sensitive-info/metadata.json
+++ b/cloudstack/compute/no-sensitive-info/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "cloudstack-compute-no-sensitive-info"
       ]

--- a/digitalocean/compute/no-public-egress/metadata.json
+++ b/digitalocean/compute/no-public-egress/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-compute-no-public-egress"
       ]

--- a/digitalocean/compute/no-public-ingress/metadata.json
+++ b/digitalocean/compute/no-public-ingress/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-compute-no-public-ingress"
       ]

--- a/digitalocean/droplet/use-ssh-keys/metadata.json
+++ b/digitalocean/droplet/use-ssh-keys/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-droplet-use-ssh-keys"
       ]

--- a/digitalocean/loadbalancing/enforce-https/metadata.json
+++ b/digitalocean/loadbalancing/enforce-https/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-loadbalancing-enforce-https"
       ]

--- a/digitalocean/spaces/acl-no-public-read/metadata.json
+++ b/digitalocean/spaces/acl-no-public-read/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-spaces-acl-no-public-read"
       ]

--- a/digitalocean/spaces/disable-force-destroy/metadata.json
+++ b/digitalocean/spaces/disable-force-destroy/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-spaces-disable-force-destroy"
       ]

--- a/digitalocean/spaces/versioning-enabled/metadata.json
+++ b/digitalocean/spaces/versioning-enabled/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "digitalocean-spaces-versioning-enabled"
       ]

--- a/general/secrets/sensitive-in-attribute-value/metadata.json
+++ b/general/secrets/sensitive-in-attribute-value/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "general-secrets-sensitive-in-attribute-value"
       ]

--- a/general/secrets/sensitive-in-attribute/metadata.json
+++ b/general/secrets/sensitive-in-attribute/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "general-secrets-sensitive-in-attribute"
       ]

--- a/general/secrets/sensitive-in-local/metadata.json
+++ b/general/secrets/sensitive-in-local/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "general-secrets-sensitive-in-local"
       ]

--- a/general/secrets/sensitive-in-variable/metadata.json
+++ b/general/secrets/sensitive-in-variable/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "general-secrets-sensitive-in-variable"
       ]

--- a/github/repositories/private/metadata.json
+++ b/github/repositories/private/metadata.json
@@ -19,12 +19,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "github-repositories-private"
       ]

--- a/google/bigquery/no-public-access/metadata.json
+++ b/google/bigquery/no-public-access/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-bigquery-no-public-access"
       ]

--- a/google/compute/disk-encryption-customer-key/metadata.json
+++ b/google/compute/disk-encryption-customer-key/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 643,
+          "name": "compute/csekEncryptionEnabled"
         }
       ],
       "tfsec": [

--- a/google/compute/disk-encryption-customer-keys/metadata.json
+++ b/google/compute/disk-encryption-customer-keys/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 643,
+          "name": "compute/csekEncryptionEnabled"
         }
       ],
       "tfsec": [

--- a/google/compute/disk-encryption-required/metadata.json
+++ b/google/compute/disk-encryption-required/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-disk-encryption-required"
       ]

--- a/google/compute/enable-shielded-vm/metadata.json
+++ b/google/compute/enable-shielded-vm/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-enable-shielded-vm"
       ]

--- a/google/compute/enable-vpc-flow-logs/metadata.json
+++ b/google/compute/enable-vpc-flow-logs/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 561,
+          "name": "vpcnetwork/flosLogsEnabled"
         }
       ],
       "tfsec": [

--- a/google/compute/no-default-service-account/metadata.json
+++ b/google/compute/no-default-service-account/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-default-service-account"
       ]

--- a/google/compute/no-ip-forwarding/metadata.json
+++ b/google/compute/no-ip-forwarding/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 641,
+          "name": "compute/ipForwardingDisabled"
         }
       ],
       "tfsec": [

--- a/google/compute/no-oslogin-override/metadata.json
+++ b/google/compute/no-oslogin-override/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-oslogin-override"
       ]

--- a/google/compute/no-plaintext-disk-keys/metadata.json
+++ b/google/compute/no-plaintext-disk-keys/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-plaintext-disk-keys"
       ]

--- a/google/compute/no-plaintext-vm-disk-keys/metadata.json
+++ b/google/compute/no-plaintext-vm-disk-keys/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-plaintext-vm-disk-keys"
       ]

--- a/google/compute/no-project-wide-ssh-keys/metadata.json
+++ b/google/compute/no-project-wide-ssh-keys/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-project-wide-ssh-keys"
       ]

--- a/google/compute/no-public-egress/metadata.json
+++ b/google/compute/no-public-egress/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-public-egress"
       ]

--- a/google/compute/no-public-ingress/metadata.json
+++ b/google/compute/no-public-ingress/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-public-ingress"
       ]

--- a/google/compute/no-public-ip/metadata.json
+++ b/google/compute/no-public-ip/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-no-public-ip"
       ]

--- a/google/compute/no-serial-port/metadata.json
+++ b/google/compute/no-serial-port/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 642,
+          "name": "compute/connectSerialPortsDisabled"
         }
       ],
       "tfsec": [

--- a/google/compute/project-level-oslogin/metadata.json
+++ b/google/compute/project-level-oslogin/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 678,
+          "name": "compute/osLoginEnabled"
         }
       ],
       "tfsec": [

--- a/google/compute/use-secure-tls-policy/metadata.json
+++ b/google/compute/use-secure-tls-policy/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-compute-use-secure-tls-policy"
       ]

--- a/google/compute/vm-disk-encryption-customer-key/metadata.json
+++ b/google/compute/vm-disk-encryption-customer-key/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 643,
+          "name": "compute/csekEncryptionEnabled"
         }
       ],
       "tfsec": [

--- a/google/dns/enable-dnssec/metadata.json
+++ b/google/dns/enable-dnssec/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 647,
+          "name": "dns/dnsSecEnabled"
         }
       ],
       "tfsec": [

--- a/google/dns/no-rsa-sha1/metadata.json
+++ b/google/dns/no-rsa-sha1/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 675,
+          "name": "dns/dnsSecSigningAlgorithm"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-auto-repair/metadata.json
+++ b/google/gke/enable-auto-repair/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 704,
+          "name": "kubernetes/autoNodeRepairEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-auto-upgrade/metadata.json
+++ b/google/gke/enable-auto-upgrade/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 705,
+          "name": "kubernetes/autoNodeUpgradesEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-ip-aliasing/metadata.json
+++ b/google/gke/enable-ip-aliasing/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 697,
+          "name": "kubernetes/aliasIpRangesEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-master-networks/metadata.json
+++ b/google/gke/enable-master-networks/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 699,
+          "name": "kubernetes/masterAuthorizedNetwork"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-network-policy/metadata.json
+++ b/google/gke/enable-network-policy/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 706,
+          "name": "kubernetes/networkPolicyEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-private-cluster/metadata.json
+++ b/google/gke/enable-private-cluster/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 719,
+          "name": "kubernetes/privateClusterEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-stackdriver-logging/metadata.json
+++ b/google/gke/enable-stackdriver-logging/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 726,
+          "name": "kubernetes/loggingEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enable-stackdriver-monitoring/metadata.json
+++ b/google/gke/enable-stackdriver-monitoring/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 565,
+          "name": "kubernetes/monitoringEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/enforce-pod-security-policy/metadata.json
+++ b/google/gke/enforce-pod-security-policy/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 707,
+          "name": "kubernetes/podSecurityPolicyEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/metadata-endpoints-disabled/metadata.json
+++ b/google/gke/metadata-endpoints-disabled/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-gke-metadata-endpoints-disabled"
       ]

--- a/google/gke/no-legacy-auth/metadata.json
+++ b/google/gke/no-legacy-auth/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 698,
+          "name": "kubernetes/legacyAuthorizationDisabled"
         }
       ],
       "tfsec": [

--- a/google/gke/no-legacy-authentication/metadata.json
+++ b/google/gke/no-legacy-authentication/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 698,
+          "name": "kubernetes/legacyAuthorizationDisabled"
         }
       ],
       "tfsec": [

--- a/google/gke/no-public-control-plane/metadata.json
+++ b/google/gke/no-public-control-plane/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 564,
+          "name": "kubernetes/privateEndpoint"
         }
       ],
       "tfsec": [

--- a/google/gke/node-metadata-security/metadata.json
+++ b/google/gke/node-metadata-security/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-gke-node-metadata-security"
       ]

--- a/google/gke/node-pool-uses-cos/metadata.json
+++ b/google/gke/node-pool-uses-cos/metadata.json
@@ -12,8 +12,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 703,
+          "name": "kubernetes/cosImageEnabled"
         }
       ],
       "tfsec": [

--- a/google/gke/node-shielding-enabled/metadata.json
+++ b/google/gke/node-shielding-enabled/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-gke-node-shielding-enabled"
       ]

--- a/google/gke/use-cluster-labels/metadata.json
+++ b/google/gke/use-cluster-labels/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-gke-use-cluster-labels"
       ]

--- a/google/gke/use-rbac-permissions/metadata.json
+++ b/google/gke/use-rbac-permissions/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-gke-use-rbac-permissions"
       ]

--- a/google/gke/use-service-account/metadata.json
+++ b/google/gke/use-service-account/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 702,
+          "name": "kubernetes/defaultServiceAccount"
         }
       ],
       "tfsec": [

--- a/google/iam/no-folder-level-default-service-account-assignment/metadata.json
+++ b/google/iam/no-folder-level-default-service-account-assignment/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-folder-level-default-service-account-assignment"
       ]

--- a/google/iam/no-folder-level-service-account-impersonation/metadata.json
+++ b/google/iam/no-folder-level-service-account-impersonation/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-folder-level-service-account-impersonation"
       ]

--- a/google/iam/no-org-level-default-service-account-assignment/metadata.json
+++ b/google/iam/no-org-level-default-service-account-assignment/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-org-level-default-service-account-assignment"
       ]

--- a/google/iam/no-org-level-service-account-impersonation/metadata.json
+++ b/google/iam/no-org-level-service-account-impersonation/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-org-level-service-account-impersonation"
       ]

--- a/google/iam/no-privileged-service-accounts/metadata.json
+++ b/google/iam/no-privileged-service-accounts/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-privileged-service-accounts"
       ]

--- a/google/iam/no-project-level-default-service-account-assignment/metadata.json
+++ b/google/iam/no-project-level-default-service-account-assignment/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-project-level-default-service-account-assignment"
       ]

--- a/google/iam/no-project-level-service-account-impersonation/metadata.json
+++ b/google/iam/no-project-level-service-account-impersonation/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-iam-no-project-level-service-account-impersonation"
       ]

--- a/google/iam/no-user-granted-permissions/metadata.json
+++ b/google/iam/no-user-granted-permissions/metadata.json
@@ -21,8 +21,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 711,
+          "name": "iam/serviceAccountUser"
         }
       ],
       "tfsec": [

--- a/google/kms/rotate-kms-keys/metadata.json
+++ b/google/kms/rotate-kms-keys/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-kms-rotate-kms-keys"
       ]

--- a/google/project/no-default-network/metadata.json
+++ b/google/project/no-default-network/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-project-no-default-network"
       ]

--- a/google/sql/enable-backup/metadata.json
+++ b/google/sql/enable-backup/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 468,
+          "name": "sql/dbAutomatedBackups"
         }
       ],
       "tfsec": [

--- a/google/sql/enable-pg-temp-file-logging/metadata.json
+++ b/google/sql/enable-pg-temp-file-logging/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-enable-pg-temp-file-logging"
       ]

--- a/google/sql/encrypt-in-transit-data/metadata.json
+++ b/google/sql/encrypt-in-transit-data/metadata.json
@@ -17,8 +17,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 679,
+          "name": "sql/dbSSLEnabled"
         }
       ],
       "tfsec": [

--- a/google/sql/mysql-no-local-infile/metadata.json
+++ b/google/sql/mysql-no-local-infile/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-mysql-no-local-infile"
       ]

--- a/google/sql/no-contained-db-auth/metadata.json
+++ b/google/sql/no-contained-db-auth/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-no-contained-db-auth"
       ]

--- a/google/sql/no-cross-db-ownership-chaining/metadata.json
+++ b/google/sql/no-cross-db-ownership-chaining/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-no-cross-db-ownership-chaining"
       ]

--- a/google/sql/no-public-access/metadata.json
+++ b/google/sql/no-public-access/metadata.json
@@ -18,7 +18,7 @@
       "cspm": [
         {
           "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "name": "sql/dbPubliclyAccessible"
         }
       ],
       "tfsec": [

--- a/google/sql/pg-log-checkpoints/metadata.json
+++ b/google/sql/pg-log-checkpoints/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-pg-log-checkpoints"
       ]

--- a/google/sql/pg-log-connections/metadata.json
+++ b/google/sql/pg-log-connections/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-pg-log-connections"
       ]

--- a/google/sql/pg-log-disconnections/metadata.json
+++ b/google/sql/pg-log-disconnections/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-pg-log-disconnections"
       ]

--- a/google/sql/pg-log-errors/metadata.json
+++ b/google/sql/pg-log-errors/metadata.json
@@ -19,12 +19,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-pg-log-errors"
       ]

--- a/google/sql/pg-log-lock-waits/metadata.json
+++ b/google/sql/pg-log-lock-waits/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-pg-log-lock-waits"
       ]

--- a/google/sql/pg-no-min-statement-logging/metadata.json
+++ b/google/sql/pg-no-min-statement-logging/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-sql-pg-no-min-statement-logging"
       ]

--- a/google/storage/enable-ubla/metadata.json
+++ b/google/storage/enable-ubla/metadata.json
@@ -21,8 +21,8 @@
       "cfsec": [],
       "cspm": [
         {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
+          "id": 644,
+          "name": "storage/bucketAllUsersPolicy"
         }
       ],
       "tfsec": [

--- a/google/storage/no-public-access/metadata.json
+++ b/google/storage/no-public-access/metadata.json
@@ -15,12 +15,7 @@
     ],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "google-storage-no-public-access"
       ]

--- a/kubernetes/network/no-public-egress/metadata.json
+++ b/kubernetes/network/no-public-egress/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "kubernetes-network-no-public-egress"
       ]

--- a/kubernetes/network/no-public-ingress/metadata.json
+++ b/kubernetes/network/no-public-ingress/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "kubernetes-network-no-public-ingress"
       ]

--- a/openstack/compute/no-plaintext-password/metadata.json
+++ b/openstack/compute/no-plaintext-password/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "openstack-compute-no-plaintext-password"
       ]

--- a/openstack/fw/no-public-access/metadata.json
+++ b/openstack/fw/no-public-access/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "openstack-fw-no-public-access"
       ]

--- a/oracle/compute/no-public-ip/metadata.json
+++ b/oracle/compute/no-public-ip/metadata.json
@@ -10,12 +10,7 @@
     "references": [],
     "externalToolIds": {
       "cfsec": [],
-      "cspm": [
-        {
-          "id": -1,
-          "name": "TODO-CSPM-PLUGIN-NAME"
-        }
-      ],
+      "cspm": [],
       "tfsec": [
         "oracle-compute-no-public-ip"
       ]


### PR DESCRIPTION
Adding the remaining CSPM cross-references;

Cross-references found for the following - 

aws/api-gateway/enable-access-logging
aws/api-gateway/enable-tracing
aws/api-gateway/no-public-access
aws/athena/enable-at-rest-encryption
aws/athena/no-encryption-override
aws/cloudfront/enable-logging
aws/cloudfront/enable-waf
aws/cloudfront/enforce-https
aws/cloudfront/use-secure-tls-policy
aws/cloudtrail/enable-all-regions
aws/cloudtrail/enable-at-rest-encryption
aws/cloudtrail/enable-log-validation
aws/dynamodb/enable-at-rest-encryption
aws/dynamodb/enable-recovery
aws/dynamodb/table-customer-key
aws/ebs/enable-volume-encryption
aws/ebs/encryption-customer-key
aws/ec2/enforce-http-token-imds
aws/ecr/enforce-immutable-repository
aws/ecr/no-public-access
aws/efs/enable-at-rest-encryption
aws/eks/enable-control-plane-logging
aws/eks/no-public-cluster-access
aws/eks/no-public-cluster-access-to-cidr
aws/elastic-search/enable-domain-encryption
aws/elastic-search/enable-domain-logging
aws/elastic-search/enable-in-transit-encryption
aws/elastic-search/enable-logging
aws/elastic-search/enforce-https
aws/elbv2/http-not-used
aws/iam/no-password-reuse
aws/iam/require-lowercase-in-passwords
aws/iam/require-numbers-in-passwords
aws/iam/require-symbols-in-passwords
aws/iam/require-uppercase-in-passwords
aws/iam/set-max-password-age
aws/iam/set-minimum-password-length
aws/kms/auto-rotate-keys
aws/rds/encrypt-cluster-storage-data
aws/rds/encrypt-instance-storage-data
aws/rds/no-public-db-access
aws/s3/enable-bucket-encryption
aws/s3/enable-bucket-logging
aws/s3/enable-versioning
aws/s3/specify-public-access-block
aws/sns/enable-topic-encryption
aws/sqs/enable-queue-encryption
aws/vpc/no-default-vpc
azure/appservice/authentication-enabled
azure/appservice/enable-http2
azure/appservice/enforce-https
azure/appservice/require-client-cert
azure/appservice/use-secure-tls-policy
azure/authorization/limit-role-actions
azure/compute/enable-disk-encryption
azure/container/use-rbac-permissions
azure/database/enable-audit
azure/database/enable-ssl-enforcement
azure/database/no-public-access
azure/database/no-public-firewall-access
azure/database/postgres-configuration-log-checkpoints
azure/database/postgres-configuration-log-connection-throttling
azure/database/retention-period-set
azure/keyvault/ensure-key-expiry
azure/keyvault/ensure-secret-expiry
azure/keyvault/no-purge
azure/monitor/activity-log-retention-set
azure/monitor/capture-all-activities
azure/monitor/capture-all-regions
azure/network/disable-rdp-from-internet
azure/network/ssh-blocked-from-internet
azure/security-center/alert-on-severe-notifications
azure/security-center/enable-standard-subscription
azure/security-center/set-required-contact-details
azure/storage/allow-microsoft-service-bypass
azure/storage/default-action-deny
azure/storage/enforce-https
azure/storage/no-public-access
google/compute/disk-encryption-customer-key
google/compute/disk-encryption-customer-keys
google/compute/enable-vpc-flow-logs
google/compute/no-ip-forwarding
google/compute/no-serial-port
google/compute/project-level-oslogin
google/compute/vm-disk-encryption-customer-key
google/dns/enable-dnssec
google/dns/no-rsa-sha1
google/gke/enable-auto-repair
google/gke/enable-auto-upgrade
google/gke/enable-ip-aliasing
google/gke/enable-master-networks
google/gke/enable-network-policy
google/gke/enable-private-cluster
google/gke/enable-stackdriver-logging
google/gke/enable-stackdriver-monitoring
google/gke/enforce-pod-security-policy
google/gke/node-pool-uses-cos
google/gke/no-legacy-auth
google/gke/no-legacy-authentication
google/gke/no-public-control-plane
google/gke/use-service-account
google/iam/no-user-granted-permissions
google/sql/enable-backup
google/sql/encrypt-in-transit-data
google/sql/no-public-access
google/storage/enable-ubla